### PR TITLE
グループ編集画面修正

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -17,6 +17,7 @@ before_action :set_group, only: [:edit, :update]
   end
 
   def edit
+    @members = @group.users.where.not(id: current_user)
   end
 
   def update

--- a/app/views/groups/_group.html.haml
+++ b/app/views/groups/_group.html.haml
@@ -17,6 +17,9 @@
       %li.list
         = current_user.name
         %input{ type: "hidden", name: "group[user_ids][]", value: current_user.id }
+      - if @group.users
+        = render partial: 'members', collection: @members, as: "user"
+
 .chat-group-form__field.clearfix
   .chat-group-form__field--left
   .chat-group-form__field--right

--- a/app/views/groups/_members.html.haml
+++ b/app/views/groups/_members.html.haml
@@ -1,0 +1,5 @@
+%li.list.select_member{ user_id: user.id, user_name: user.name }
+  = user.name
+  %span.chat-group-user__btn--remove
+    削除
+  %input{ type: "hidden", name: "group[user_ids][]", value: user.id }


### PR DESCRIPTION
# WHAT
グループ編集画面にて、現在の登録メンバーが表示されるよう修正

# WHY
ログインメンバーしか表示されず、ユーザビリティが悪いため